### PR TITLE
Create 2018-12-26-kerstkampen

### DIFF
--- a/templates/assets/2018-12-26-kerstkampen
+++ b/templates/assets/2018-12-26-kerstkampen
@@ -1,0 +1,45 @@
+---
+layout: post
+title:  "Basketbal voor de jeugd tijdens de kerstperiode"
+cover: /news/img/uwfoto.png
+date:   2018-10-25 20:00:00
+description: Basketbal voor de jeugd, ook tijdens de kerstperiode!.
+permalink: /news/vervang-dit-door-de-bestandsnaam-zonder-extensie/
+---
+
+Ook tijdens de kerstperiode zullen de jeugdspelers van Basket Lummen leerrijke ervaringen kunnen opdoen. Er is niet alleen het FROS-kamp, met coaches van Basket Lummen, maar ook het Bounce Camp Hans Vanwijn, een voormalig speler van Basket Lummen. Verder volgt er nog een evenement (Brecht)..... details...?
+
+## FROS-kamp
+
+Locale coaches, zoals Jolien Wouters, Janne Wouters en Caro Swolfs, hebben een ijzersterk concept voor de beginnende en gevorderde basketter. Het kamp is al jarenlang een vaste waarde in Limburg en bundelt heel wat ervaring. Het wordt georganiseerd door Bart Wouters, die onze DSE-A-ploeg ondersteunt.
+
+### Voor wie?
+
+Voor jongens en meisjes vanaf 7 jaar, met minimaal 1 jaar basketervaring.
+
+### Praktisch
+
+Op 26, 27, en 28 december in de sporthal van Lummen, van 09h00 tot 16h00.
+
+### Inschrijven
+
+In de bijgevoegde folder vind je alle informatie om in te schrijven.  [link naar .pdf bestand maken]
+
+## Bounce Camp Hans Vanwijn
+
+In januari 
+
+## evenement Brecht - details ontbreken nog
+
+
+Wil je verwijzen naar een andere pagina op de site, gebruik dan [deze notatie](/news/ander-bericht)
+
+Wil je verwijzen naar een pagina op een andere site, gebruik dan [deze notatie](http://www.andere-site.com/pagina)
+
+Wil je een email link aanbieden, gebruik dan deze notatie: [uw.email@provider.be](mailto://uw.email@provider.be)
+
+Wil je een foto integreren in je tekst, gebruik dan onderstaande notatie (let op het uitroepteken vooraan!).
+
+![naam van de foto](/news/img/nogeenfoto.png)
+
+Het tekst formaat dat hier gebruikt werd, heet Markdown. Als je meer geavanceerde dingen wil voorzien in je artikel dan kan dat, hier is [een handige cheatsheet](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet) waar je een overzicht vind van alle Markdown opties.


### PR DESCRIPTION
---
layout: post
title:  "Basketbal voor de jeugd tijdens de kerstperiode"
cover: /BasketLummen/Website/_content/albums/2018-10-13-Basket-Lummen-DSEA-Sint-Katelijne-Waver-DSEA/_thumbnails/IMG_6412.jpg
date:   2018-10-25 20:00:00
description: Basketbal voor de jeugd, ook tijdens de kerstperiode!.
permalink: /news/vervang-dit-door-de-bestandsnaam-zonder-extensie/
---

Ook tijdens de kerstperiode zullen de jeugdspelers van Basket Lummen leerrijke ervaringen kunnen opdoen. Er is niet alleen het FROS-kamp, met coaches van Basket Lummen, maar ook het Bounce Camp Hans Vanwijn, een voormalig speler van Basket Lummen. Verder volgt er nog een evenement (Brecht)..... details...?

## FROS-kamp

Locale coaches, zoals Jolien Wouters, Janne Wouters en Caro Swolfs, hebben een ijzersterk concept voor de beginnende en gevorderde basketter. Het kamp is al jarenlang een vaste waarde in Limburg en bundelt heel wat ervaring. Het wordt georganiseerd door Bart Wouters, die onze DSE-A-ploeg ondersteunt.

#### Voor wie?
Voor jongens en meisjes vanaf 7 jaar, met minimaal 1 jaar basketervaring.

#### Praktisch
Op 26, 27, en 28 december in de sporthal van Lummen, van 09h00 tot 16h00.

#### Inschrijven
In de bijgevoegde folder vind je alle informatie om in te schrijven. |link naar .pdf-bestand toevoegen|

## Bounce Camp Hans Vanwijn

Hans Vanwijn, een voormalig speler van Basket Lummen, leidt een aantal coaches, die hun ervaring bij Limburg United zullen gebruiken voor onze jeugdspelers. 

#### Voor wie?
Voor jongens en meisjes tussen 10 en 16 jaar, met minimaal 1 jaar basketervaring.

#### Praktisch
Op 2, 3 en 4 januari, Bogaarsveldstraat in Beringen.

#### Inschrijven
Via deze link kan je de inschrijving regelen: [www.hansvanwijn.be](https://www.hansvanwijn.be/kampen/)

## evenement Brecht 

details ontbreken nog

#### Voor wie?
Voor 

#### Praktisch
Op 

#### Inschrijven
Via



Wil je verwijzen naar een andere pagina op de site, gebruik dan [deze notatie](/news/ander-bericht)

Wil je verwijzen naar een pagina op een andere site, gebruik dan [deze notatie](http://www.andere-site.com/pagina)

Wil je een email link aanbieden, gebruik dan deze notatie: [uw.email@provider.be](mailto://uw.email@provider.be)

Wil je een foto integreren in je tekst, gebruik dan onderstaande notatie (let op het uitroepteken vooraan!).

![naam van de foto](/news/img/nogeenfoto.png)


Het tekst formaat dat hier gebruikt werd, heet Markdown. Als je meer geavanceerde dingen wil voorzien in je artikel dan kan dat, hier is [een handige cheatsheet](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet) waar je een overzicht vind van alle Markdown opties.